### PR TITLE
feat(engines): Increase localServerStart timeout

### DIFF
--- a/ComfyUI/src/config.ts
+++ b/ComfyUI/src/config.ts
@@ -15,4 +15,5 @@ export const config = {
   clientServerPort: 9000,
   serverFilePath: path.join(__dirname, './server.js'),
   configurationPath: process.env.CONFIGURATION_PATH || '/sp/configurations/configuration.json',
+  localServerStartTimeoutMs: Number.parseInt(process.env.LOCAL_SERVER_START_TIMEOUT_MS || '300000'), // 5 min
 };

--- a/ComfyUI/src/index.ts
+++ b/ComfyUI/src/index.ts
@@ -35,6 +35,7 @@ const run = async (): Promise<void> => {
     logger: rootLogger,
     applicationPort: config.clientServerPort,
     sgxMockEnabled: true,
+    localServerStartTimeout: config.localServerStartTimeoutMs,
   };
   const tunnelClient = new TunnelClient(config.serverFilePath, domainConfigs, options);
   await tunnelClient.start();

--- a/Text Generation WebUI/src/config.ts
+++ b/Text Generation WebUI/src/config.ts
@@ -20,4 +20,5 @@ export const config = {
   clientServerPort: 9000,
   serverFilePath: path.join(__dirname, './server.js'),
   configurationPath: process.env.CONFIGURATION_PATH || '/sp/configurations/configuration.json',
+  localServerStartTimeoutMs: Number.parseInt(process.env.LOCAL_SERVER_START_TIMEOUT_MS || '300000'), // 5 min
 };

--- a/Text Generation WebUI/src/index.ts
+++ b/Text Generation WebUI/src/index.ts
@@ -35,6 +35,7 @@ const run = async (): Promise<void> => {
     logger: rootLogger,
     applicationPort: config.clientServerPort,
     sgxMockEnabled: true,
+    localServerStartTimeout: config.localServerStartTimeoutMs,
   };
   const tunnelClient = new TunnelClient(config.serverFilePath, domainConfigs, options);
   await tunnelClient.start();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
	- Added a new configuration option `localServerStartTimeoutMs` to control local server startup timeout
	- Default timeout set to 5 minutes (300,000 milliseconds) if not specified
	- Allows customization of server startup waiting period through environment variable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->