### PR TITLE
fix(comfyui): force CLI only mode for CM

### DIFF
--- a/ComfyUI/Dockerfile.prod
+++ b/ComfyUI/Dockerfile.prod
@@ -83,7 +83,18 @@ RUN comfy --skip-prompt tracking disable
 RUN comfy --skip-prompt --workspace $COMFYUI_PATH install --version $COMFYUI_VERSION --manager-commit $COMFYUI_MANAGER_VERSION --nvidia --cuda-version=12.4
 
 RUN comfy --skip-prompt set-default ${COMFYUI_PATH}
+
+# Creating ComfyUI Manager config file
+RUN mkdir -p ${COMFYUI_PATH}/user/default/ComfyUI-Manager
+RUN <<EOF cat >> ${COMFYUI_PATH}/user/default/ComfyUI-Manager/config.ini
+[default]
+security_level = strong
+EOF
+# FIXME: following command is failing for some reason - 
 RUN comfy manager disable-gui
+# simulating the same command
+# see https://github.com/jiangyangfan/ComfyUI-Manager/blob/5bf9914e17244560ef69ad4de218150fa755e88d/cm-cli.py#L748-L764
+RUN echo "yes" > ${COMFYUI_PATH}/custom_nodes/ComfyUI-Manager/.enable-cli-only-mode
 
 # Change into ComfyUI directory
 WORKDIR ${COMFYUI_PATH}


### PR DESCRIPTION
After this change:

<img width="1716" alt="no-cm" src="https://github.com/user-attachments/assets/2cad0bd9-8de9-4743-ba25-a6bb44134711" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced container startup and configuration processes for improved service stability and security.
  - Introduced health monitoring to ensure the application runs consistently.
  - Added a fallback command-line mode for environments without full graphical support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->