### PR TITLE
ci(build-engine): use private SPCTL repository for 'testnet'  (SP-6909)

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -73,7 +73,7 @@ jobs:
             SUBMODULE_PATH="Dia TTS Server/dia-tts-server"
             DOCKERFILE="./Dia TTS Server/Dockerfile"
             DOCKERFILE_CONTEXT="./Dia TTS Server/"
-            
+
           else
             echo "Invalid solution name"
             exit 1
@@ -126,7 +126,7 @@ jobs:
 
       - name: Set SPCTL repository type
         run: |
-          if [ "$TARGET" == "develop" || "$TARGET" == "stage" ]; then
+          if [ "$TARGET" == "develop" || "$TARGET" == "stage" || "$TARGET" == "testnet" ]; then
             SPCTL_REPOSITORY_TYPE=private
           else
             SPCTL_REPOSITORY_TYPE=public


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to align testnet handling with other environments, improving consistency and reliability of testnet builds.
* **Style**
  * Minor whitespace cleanup in workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->